### PR TITLE
Use let-else, if-let and similar instead of many unwraps

### DIFF
--- a/src/action.rs
+++ b/src/action.rs
@@ -135,8 +135,8 @@ impl Action {
         match self {
             Action::SendPadding { timeout, limit, .. } => {
                 timeout.validate()?;
-                if limit.is_some() {
-                    limit.unwrap().validate()?;
+                if let Some(limit) = limit {
+                    limit.validate()?;
                 }
             }
             Action::BlockOutgoing {
@@ -147,16 +147,16 @@ impl Action {
             } => {
                 timeout.validate()?;
                 duration.validate()?;
-                if limit.is_some() {
-                    limit.unwrap().validate()?;
+                if let Some(limit) = limit {
+                    limit.validate()?;
                 }
             }
             Action::UpdateTimer {
                 duration, limit, ..
             } => {
                 duration.validate()?;
-                if limit.is_some() {
-                    limit.unwrap().validate()?;
+                if let Some(limit) = limit {
+                    limit.validate()?;
                 }
             }
             _ => {}

--- a/src/counter.rs
+++ b/src/counter.rs
@@ -61,8 +61,8 @@ impl CounterUpdate {
 
     // Validate the value dist.
     pub fn validate(&self) -> Result<(), Box<dyn Error + Send + Sync>> {
-        if self.value.is_some() {
-            self.value.unwrap().validate()?;
+        if let Some(value) = self.value {
+            value.validate()?;
         }
         Ok(())
     }

--- a/src/framework.rs
+++ b/src/framework.rs
@@ -469,19 +469,17 @@ where
         }
 
         // sample next state
-        let next_state;
         // new block for immutable ref, makes things less ugly
-        {
+        let next_state = {
             let machine = &self.machines.as_ref()[mi];
             let state = &machine.states[self.runtime[mi].current_state];
-            next_state = state.sample_state(event);
-        }
+            state.sample_state(event)
+        };
 
         // if no next state on event, done
-        if next_state.is_none() {
+        let Some(next_state) = next_state else {
             return StateChange::Unchanged;
-        }
-        let next_state = next_state.unwrap();
+        };
 
         // we got a next state, act on it
         match next_state {
@@ -620,11 +618,11 @@ where
     fn below_action_limits(&self, runtime: &MachineRuntime, machine: &Machine) -> bool {
         let current = &machine.states[runtime.current_state];
 
-        if current.action.is_none() {
+        let Some(action) = current.action else {
             return false;
-        }
+        };
 
-        match current.action.unwrap() {
+        match action {
             Action::BlockOutgoing { .. } => self.below_limit_blocking(runtime, machine),
             Action::SendPadding { .. } => self.below_limit_padding(runtime, machine),
             Action::UpdateTimer { .. } => runtime.state_limit > 0,

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -138,19 +138,16 @@ pub fn parse_state(buf: Vec<u8>, num_states: usize) -> Result<State, Box<dyn Err
     r += 1;
 
     let action: Option<Action>;
-    if timeout.is_none() {
-        action = None;
-    } else {
-        let timeout = timeout.unwrap();
+    if let Some(timeout) = timeout {
         if action_is_block {
-            if duration.is_none() {
-                bail!("action dist is None")
-            }
+            let Some(duration) = duration else {
+                bail!("action dist is None");
+            };
             action = Some(Action::BlockOutgoing {
                 bypass,
                 replace,
                 timeout,
-                duration: duration.unwrap(),
+                duration,
                 limit,
             });
         } else {
@@ -161,6 +158,8 @@ pub fn parse_state(buf: Vec<u8>, num_states: usize) -> Result<State, Box<dyn Err
                 limit,
             });
         };
+    } else {
+        action = None;
     }
 
     //let limit_includes_nonpadding: bool = buf[r] == 1;

--- a/src/state.rs
+++ b/src/state.rs
@@ -102,10 +102,9 @@ impl State {
     pub fn validate(&self, num_states: usize) -> Result<(), Box<dyn Error + Send + Sync>> {
         // validate transition probabilities
         for (event, transitions) in self.transitions.iter().enumerate() {
-            if transitions.is_none() {
+            let Some(transitions) = transitions else {
                 continue;
-            }
-            let transitions = transitions.as_ref().unwrap();
+            };
             if self.transitions.is_empty() {
                 bail!("found empty transition vector for {}", &event);
             }
@@ -185,10 +184,7 @@ fn make_alias_index(
     let mut alias = [ARRAY_NO_ALIAS; EVENT_NUM];
 
     for (event, vector) in transitions.iter().enumerate() {
-        if vector.is_none() {
-            continue;
-        }
-        let vector = vector.as_ref().unwrap();
+        let Some(vector) = vector else { continue };
 
         let mut weights = Vec::new();
         let mut choices = Vec::new();


### PR DESCRIPTION
Unwraps are sometimes not really possible to avoid, but many times they are code smells.

I saw many instances of:
```rust
if an_optional.is_some() {
   an_optional.unwrap().some_operation();
}
```
These can be simplified to the following:
```rust
if let Some(value) = an_optional {
    value.some_operation();
}
```

And a lot of:
```rust
if some_optional.is_none() {
    return ...;
}
let value = some_optional.unwrap();
```
Which can be simplified to:
```rust
let Some(value) = some_optional else {
    return ...;
};
```

Which IMHO is both simpler to read, and avoids potentially panicking code paths etc. Simpler for the compiler to reason about and optimize. And will most likely produce way nicer output code even when optimization is not enabled. This is more idiomatic and helps catch errors that liberal use of `.unwrap()` could potentially hide.

You can read about the `let-else` construct here, it's a very handy language feature: https://doc.rust-lang.org/beta/rust-by-example/flow_control/let_else.html