### PR TITLE
Don't expose the `framework`, `machine` and `error` modules

### DIFF
--- a/src/action.rs
+++ b/src/action.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 
 use self::dist::Dist;
 
-/// The different types of timers used by a [`Machine`](crate::machine).
+/// The different types of timers used by a [`Machine`].
 #[derive(Debug, Eq, Hash, PartialEq, Clone, Copy, Serialize, Deserialize)]
 pub enum Timer {
     /// The scheduled timer for actions with a timeout.

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,10 +1,10 @@
 //! Global constants for the framework.
 
-/// The highest possible version of a [`Machine`](crate::machine) supported by
+/// The highest possible version of a [`Machine`](crate::Machine) supported by
 /// this framework.
 pub const VERSION: u8 = 2;
 
-/// The maximum size of a decompressed encoded [`Machine`](crate::machine) in
+/// The maximum size of a decompressed encoded [`Machine`](crate::Machine) in
 /// bytes. Set to 1MB. This is a soft limit and can be increased if necessary.
 pub const MAX_DECOMPRESSED_SIZE: usize = 1 << 20;
 
@@ -35,9 +35,9 @@ pub const STATE_LIMIT_MAX: u64 = u64::MAX;
 /// in a transition: it is used for state transitions as a "no-op" transition
 /// for any remaining probability up until 1.0.
 pub const STATE_NOP: usize = u32::MAX as usize;
-/// A pseudo-state that means the [`Machine`](crate::machine) should completely
+/// A pseudo-state that means the [`Machine`](crate::Machine) should completely
 /// stop.
 pub const STATE_END: usize = STATE_NOP - 1;
-/// The maximum number of [`State`](crate::state)s a [`Machine`](crate::machine)
+/// The maximum number of [`State`](crate::state)s a [`Machine`](crate::Machine)
 /// can have.
 pub const STATE_MAX: usize = STATE_END - 1;

--- a/src/counter.rs
+++ b/src/counter.rs
@@ -1,4 +1,4 @@
-//! Counters as part of a [`Machine`](crate::machine).
+//! Counters as part of a [`Machine`].
 
 use rand::Rng;
 use serde::{Deserialize, Serialize};
@@ -9,15 +9,15 @@ use std::fmt;
 
 use self::dist::Dist;
 
-/// The two counters that are part of each [`Machine`](crate::machine).
+/// The two counters that are part of each [`Machine`].
 #[derive(Debug, Eq, Hash, PartialEq, Clone, Copy, Serialize, Deserialize)]
 pub enum Counter {
     A,
     B,
 }
 
-/// The operation applied to a [`Machine`](crate::machine)'s counters upon
-/// transition to a [`State`](crate::state).
+/// The operation applied to a [`Machine`]'s counters upon
+/// transition to a [`State`](crate::state::State).
 #[derive(Debug, Eq, Hash, PartialEq, Clone, Copy, Serialize, Deserialize)]
 pub enum Operation {
     /// Increment the counter by the sampled value.
@@ -28,9 +28,9 @@ pub enum Operation {
     Set,
 }
 
-/// A specification of how a [`Machine`](crate::machine)'s counters should be
-/// updated when transitioning to a [`State`](crate::machine). Consists of a
-/// [`Counter`], an [`Operation`] to be applied to the counter, and a
+/// A specification of how a [`Machine`]'s counters should be
+/// updated when transitioning to a [`State`](crate::state::State). Consists of
+/// a [`Counter`], an [`Operation`] to be applied to the counter, and a
 /// distribution to sample values from when updating the counter.
 #[derive(PartialEq, Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct CounterUpdate {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,10 +13,10 @@
 //! modules can be ignored. Note that you create an existing [`Machine`] (for
 //! use with the [`Framework`]) using the [`core::str::FromStr`] trait.
 //!
-//! If you want to build machines for the [`framework`], take a look at all the
-//! modules. For top-down, start with [`machine`]. For bottom-up, start with
-//! [`dist`], [`event`], [`action`], and [`counter`] before [`state`] and
-//! finally [`machine`].
+//! If you want to build machines for the [`Framework`], take a look at all the
+//! modules. For top-down, start with the [`Machine`] type. For bottom-up, start
+//! with [`dist`], [`event`], [`action`], and [`counter`] before [`state`] and
+//! finally [`Machine`].
 //!
 //! ## Example usage
 //! ```
@@ -209,15 +209,15 @@ pub mod counter;
 pub mod dist;
 pub mod error;
 pub mod event;
-pub mod framework;
-pub mod machine;
+mod framework;
+mod machine;
 pub mod state;
 
 pub use crate::action::{Timer, TriggerAction};
 pub use crate::error::Error;
 pub use crate::event::TriggerEvent;
-pub use crate::framework::{Framework, MachineId};
-pub use crate::machine::Machine;
+pub use framework::{Framework, MachineId};
+pub use machine::Machine;
 
 #[cfg(feature = "parsing")]
 pub mod parsing;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,7 +207,7 @@ pub mod action;
 pub mod constants;
 pub mod counter;
 pub mod dist;
-pub mod error;
+mod error;
 pub mod event;
 mod framework;
 mod machine;

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,4 +1,4 @@
-//! A state as part of a [`Machine`](crate::machine). Contains an optional
+//! A state as part of a [`Machine`]. Contains an optional
 //! [`Action`] and [`CounterUpdate`] to be executed upon transition to this
 //! state, and a vector of state transitions for each possible [`Event`].
 
@@ -28,7 +28,7 @@ impl fmt::Display for Trans {
     }
 }
 
-/// A state as part of a [`Machine`](crate::machine).
+/// A state as part of a [`Machine`].
 #[derive(Debug, Clone, Serialize)]
 pub struct State {
     /// Take an action upon transitioning to this state.
@@ -72,7 +72,7 @@ impl State {
     /// [`Event::PaddingSent`] and to state 2 on [`Event::CounterZero`], both
     /// with 100% probability. All other events will not cause a transition.
     /// Note that state indexes are 0-based and determined by the order in which
-    /// states are added to the [`Machine`](crate::machine).
+    /// states are added to the [`Machine`].
     pub fn new(t: EnumMap<Event, Vec<Trans>>) -> Self {
         const ARRAY_NO_TRANS: std::option::Option<Vec<Trans>> = None;
         let mut transitions = [ARRAY_NO_TRANS; EVENT_NUM];


### PR DESCRIPTION
This PR makes the `framework`, `machine` and `error` modules not public. They only contain types which are already exposed at the top level of the crate, so no need to expose them twice. IMHO it just increase the API surface and makes things harder to navigate. With this PR the main types are available directly in the root, and way fewer modules for the user to navigate when reading the docs.

This also changes all documentation links to point to the *types* rather than the *modules*. I did not do a thorough read to see if this made sense, but it looked like pointing to the type was appropriate.