### PR TITLE
Fix `clippy` lint `lint_groups_priority`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ members = [
 non_ascii_idents = "forbid"
 
 # Deny old style Rust
-rust_2018_idioms = "deny"
+rust_2018_idioms = { level = "deny", priority = -1 }
 macro_use_extern_crate = "deny"
 absolute_paths_not_starting_with_crate = "deny"
 


### PR DESCRIPTION
`clippy` complains about the `rust_2018_idioms` lint having the same priority as other lints: https://rust-lang.github.io/rust-clippy/master/index.html#/lint_groups_priority

```bash
$ cargo clippy
    Checking maybenot v1.1.2 (<redacted>/maybenot)
error: lint group `rust_2018_idioms` has the same priority (0) as a lint
  --> Cargo.toml:28:1
   |
28 | rust_2018_idioms = "deny"
   | ^^^^^^^^^^^^^^^^   ------ has an implicit priority of 0
29 | macro_use_extern_crate = "deny"
   | ---------------------- has the same priority as this lint
   |
   = note: the order of the lints in the table is ignored by Cargo
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#lint_groups_priority
   = note: `#[deny(clippy::lint_groups_priority)]` on by default
help: to have lints override the group set `rust_2018_idioms` to a lower priority
   |
28 | rust_2018_idioms = { level = "deny", priority = -1 }
   |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

error: could not compile `maybenot` (lib) due to 1 previous error
```

This fixes the issue by giving the offending group a lower priority.