### PR TITLE
feat: extended counter updates and add signalling.

### DIFF
--- a/crates/maybenot-simulator/src/lib.rs
+++ b/crates/maybenot-simulator/src/lib.rs
@@ -45,7 +45,7 @@
 //!
 //! // A simple machine that sends one padding packet 20 milliseconds after the
 //! // first normal packet is sent.
-//! let m = "02eNptibEJAAAIw1of09Mc/c+HRMFFzFBoAlxkliTgurLfT6T9oQBWJgJi";
+//! let m = "02eNp1ibEJAEAIA5Nf7B3N0v1cSESwEL0m5A6YvBqSgP7WeXfM5UoBW7ICYg==";
 //! let m = Machine::from_str(m).unwrap();
 //!
 //! // Run the simulator with the machine at the client. Run the simulation up

--- a/crates/maybenot-simulator/tests/example.rs
+++ b/crates/maybenot-simulator/tests/example.rs
@@ -34,7 +34,7 @@ fn simple_machine_for_example() {
     let m = Machine::new(0, 0.0, 0, 0.0, vec![s0, s1]).unwrap();
     assert_eq!(
         m.serialize(),
-        "02eNptibEJAAAIw1of09Mc/c+HRMFFzFBoAlxkliTgurLfT6T9oQBWJgJi"
+        "02eNp1ibEJAEAIA5Nf7B3N0v1cSESwEL0m5A6YvBqSgP7WeXfM5UoBW7ICYg=="
     );
 }
 
@@ -67,7 +67,7 @@ fn simulator_example_use() {
 
     // A simple machine that sends one padding packet 20 milliseconds after the
     // first normal packet is sent.
-    let m = "02eNptibEJAAAIw1of09Mc/c+HRMFFzFBoAlxkliTgurLfT6T9oQBWJgJi";
+    let m = "02eNp1ibEJAEAIA5Nf7B3N0v1cSESwEL0m5A6YvBqSgP7WeXfM5UoBW7ICYg==";
     let m = Machine::from_str(m).unwrap();
 
     // Run the simulator with the machine at the client. Run the simulation up

--- a/crates/maybenot-simulator/tests/simulator.rs
+++ b/crates/maybenot-simulator/tests/simulator.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 
 use maybenot::{
     action::Action,
-    counter::{Counter, CounterUpdate, Operation},
+    counter::{Counter, Operation},
     dist::{Dist, DistType},
     event::Event,
     state::{State, Trans},
@@ -1086,44 +1086,44 @@ fn test_counter_machine() {
         Event::NormalRecv => vec![Trans(2, 1.0)],
         _ => vec![],
     });
-    s1.counter = Some(CounterUpdate {
-        counter: Counter::A,
-        operation: Operation::Increment,
-        value: Some(Dist {
-            dist: DistType::Uniform {
-                low: 5.0,
-                high: 5.0,
+    s1.counter = (
+        Some(Counter::new_dist(
+            Operation::Increment,
+            Dist {
+                dist: DistType::Uniform {
+                    low: 5.0,
+                    high: 5.0,
+                },
+                start: 0.0,
+                max: 0.0,
             },
-            start: 0.0,
-            max: 0.0,
-        }),
-    });
+        )),
+        None,
+    );
     let mut s2 = State::new(enum_map! {
         Event::NormalRecv => vec![Trans(3, 1.0)],
         _ => vec![],
     });
-    s2.counter = Some(CounterUpdate {
-        counter: Counter::A,
-        operation: Operation::Decrement,
-        value: Some(Dist {
-            dist: DistType::Uniform {
-                low: 2.0,
-                high: 2.0,
+    s2.counter = (
+        Some(Counter::new_dist(
+            Operation::Decrement,
+            Dist {
+                dist: DistType::Uniform {
+                    low: 2.0,
+                    high: 2.0,
+                },
+                start: 0.0,
+                max: 0.0,
             },
-            start: 0.0,
-            max: 0.0,
-        }),
-    });
+        )),
+        None,
+    );
     let mut s3 = State::new(enum_map! {
         Event::NormalSent => vec![Trans(3, 1.0)],
         Event::CounterZero => vec![Trans(4, 1.0)],
         _ => vec![],
     });
-    s3.counter = Some(CounterUpdate {
-        counter: Counter::A,
-        operation: Operation::Decrement,
-        value: None, // same as 1
-    });
+    s3.counter = (Some(Counter::new(Operation::Decrement)), None);
     let mut s4 = State::new(enum_map! {
         _ => vec![],
     });
@@ -1153,13 +1153,9 @@ fn test_counter_machine() {
         false,
     );
 
-    // set counter in state 3 to Counter::B, to prevent the CounterZero event
+    // set counter in state 3 to Counter B, to prevent the CounterZero event
     // from firing
-    m.states[3].counter = Some(CounterUpdate {
-        counter: Counter::B,
-        operation: Operation::Decrement,
-        value: None,
-    });
+    m.states[3].counter = (None, Some(Counter::new(Operation::Decrement)));
     run_test_sim(
         "0,sn 6,rn 6,rn 7,sn 7,sn 7,sn",
         "0,sn 0,st 6,rt 6,rt 6,rn 6,rn 7,sn 7,st 7,sn 7,st 7,sn 7,st",
@@ -1171,31 +1167,35 @@ fn test_counter_machine() {
         false,
     );
 
-    // update state 1 and 2 to also use Counter::B
-    m.states[1].counter = Some(CounterUpdate {
-        counter: Counter::B,
-        operation: Operation::Increment,
-        value: Some(Dist {
-            dist: DistType::Uniform {
-                low: 5.0,
-                high: 5.0,
+    // update state 1 and 2 to also use Counter B
+    m.states[1].counter = (
+        None,
+        Some(Counter::new_dist(
+            Operation::Increment,
+            Dist {
+                dist: DistType::Uniform {
+                    low: 5.0,
+                    high: 5.0,
+                },
+                start: 0.0,
+                max: 0.0,
             },
-            start: 0.0,
-            max: 0.0,
-        }),
-    });
-    m.states[2].counter = Some(CounterUpdate {
-        counter: Counter::B,
-        operation: Operation::Decrement,
-        value: Some(Dist {
-            dist: DistType::Uniform {
-                low: 2.0,
-                high: 2.0,
+        )),
+    );
+    m.states[2].counter = (
+        None,
+        Some(Counter::new_dist(
+            Operation::Decrement,
+            Dist {
+                dist: DistType::Uniform {
+                    low: 2.0,
+                    high: 2.0,
+                },
+                start: 0.0,
+                max: 0.0,
             },
-            start: 0.0,
-            max: 0.0,
-        }),
-    });
+        )),
+    );
     run_test_sim(
         "0,sn 6,rn 6,rn 7,sn 7,sn 7,sn",
         "0,sn 0,st 6,rt 6,rt 6,rn 6,rn 7,sn 7,st 7,sn 7,st 7,sn 7,st 10,sp 10,st",
@@ -1208,18 +1208,20 @@ fn test_counter_machine() {
     );
 
     // replace increment in state 1 with set operation, should make no difference
-    m.states[1].counter = Some(CounterUpdate {
-        counter: Counter::B,
-        operation: Operation::Set,
-        value: Some(Dist {
-            dist: DistType::Uniform {
-                low: 5.0,
-                high: 5.0,
+    m.states[1].counter = (
+        None,
+        Some(Counter::new_dist(
+            Operation::Set,
+            Dist {
+                dist: DistType::Uniform {
+                    low: 5.0,
+                    high: 5.0,
+                },
+                start: 0.0,
+                max: 0.0,
             },
-            start: 0.0,
-            max: 0.0,
-        }),
-    });
+        )),
+    );
     run_test_sim(
         "0,sn 6,rn 6,rn 7,sn 7,sn 7,sn",
         "0,sn 0,st 6,rt 6,rt 6,rn 6,rn 7,sn 7,st 7,sn 7,st 7,sn 7,st 10,sp 10,st",

--- a/crates/maybenot/CHANGELOG.md
+++ b/crates/maybenot/CHANGELOG.md
@@ -20,13 +20,18 @@ Manually generated changelog, for now. We follow semantic versioning.
   machines and effectively dealing with blocking actions.
 - Added two counters per machine which are updated upon transition to a state if
   its `counter` field is set. A `CounterZero` event is triggered when either of
-  a machine's counters is decremented to zero.
+  a machine's counters is decremented to zero. Counters are internal to the
+  framework and are not exposed to the integrator.
 - Added a per-machine "internal" timer which can be set using an `UpdateTimer`
-  action. These are handled by the integrator, who triggers the corresponding
-  `TimerBegin` and `TimerEnd` events as the timer starts and fire.
+  action. These are handled by the integrator (to not impose any particular
+  runtime for timers), who triggers the corresponding `TimerBegin` and
+  `TimerEnd` events as the timer starts and fire.
 - Extended the `Cancel` action that can be used to cancel a pending action timer
   (timeout), the machine's internal timer, or both. The internal pseudo-state
   `STATE_CANCEL` transition is removed.
+- Added support for `Event::Signal`, allowing machines to signal between each
+  other. Useful for multiple machines that need to coordinate their states. This
+  is internal to the framework and is not exposed to the integrator.
 - Added support for the `SkewNormal` distribution.
 - Added an optional `parsing` feature to reconstruct v1 machines, though they
   may behave differently than expected. v1 machines are now deprecated.

--- a/crates/maybenot/src/constants.rs
+++ b/crates/maybenot/src/constants.rs
@@ -9,7 +9,7 @@ pub const VERSION: u8 = 2;
 pub const MAX_DECOMPRESSED_SIZE: usize = 1 << 20;
 
 /// The number of [`Event`](crate::event)s in the framework.
-pub const EVENT_NUM: usize = 12;
+pub const EVENT_NUM: usize = 13;
 
 /// The maximum sampled timeout in a [`State`](crate::state), set to a day in
 /// microseconds.
@@ -38,6 +38,9 @@ pub const STATE_NOP: usize = u32::MAX as usize;
 /// A pseudo-state that means the [`Machine`](crate::Machine) should completely
 /// stop.
 pub const STATE_END: usize = STATE_NOP - 1;
+/// A pseudo-state that triggers a Signal [`Event`](crate::event) in all other
+/// running machines.
+pub const STATE_SIGNAL: usize = STATE_END - 1;
 /// The maximum number of [`State`](crate::state)s a [`Machine`](crate::Machine)
 /// can have.
-pub const STATE_MAX: usize = STATE_END - 1;
+pub const STATE_MAX: usize = STATE_SIGNAL - 1;

--- a/crates/maybenot/src/counter.rs
+++ b/crates/maybenot/src/counter.rs
@@ -9,62 +9,92 @@ use std::fmt;
 
 use self::dist::Dist;
 
-/// The two counters that are part of each [`Machine`].
-#[derive(Debug, Eq, Hash, PartialEq, Clone, Copy, Serialize, Deserialize)]
-pub enum Counter {
-    A,
-    B,
-}
-
-/// The operation applied to a [`Machine`]'s counters upon
-/// transition to a [`State`](crate::state::State).
+/// The operation applied to one of a [`Machine`]'s counters upon transition to
+/// a [`State`](crate::state::State).
 #[derive(Debug, Eq, Hash, PartialEq, Clone, Copy, Serialize, Deserialize)]
 pub enum Operation {
-    /// Increment the counter by the sampled value.
+    /// Increment the counter.
     Increment,
-    /// Decrement the counter by the sampled value.
+    /// Decrement the counter.
     Decrement,
-    /// Replace the current value of the counter with the sampled one.
+    /// Replace the current value of the counter.
     Set,
 }
 
-/// A specification of how a [`Machine`]'s counters should be
-/// updated when transitioning to a [`State`](crate::state::State). Consists of
-/// a [`Counter`], an [`Operation`] to be applied to the counter, and a
-/// distribution to sample values from when updating the counter.
+/// A specification of how one of a [`Machine`]'s counters should be updated
+/// when transitioning to a [`State`](crate::state::State). Consists of an
+/// [`Operation`] to be applied to the counter with one of three values: by
+/// default, the value 1, unless a distribution is provided or the copy flag is
+/// set to true. If the copy flag is set to true, the counter will be updated
+/// with the value of the other counter *prior to transitioning to the state*.
+/// If a distribution is provided, the counter will be updated with a value
+/// sampled from the distribution.
 #[derive(PartialEq, Debug, Clone, Copy, Serialize, Deserialize)]
-pub struct CounterUpdate {
-    /// Which counter to update.
-    pub counter: Counter,
-    /// The operation to apply to the counter upon a state transition.
+pub struct Counter {
+    /// The operation to apply to the counter upon a state transition. If the
+    /// distribution is not set and copy is false, the counter will be updated
+    /// by 1.
     pub operation: Operation,
     /// If set, sample the value to update the counter with from a
-    /// distribution. If not set, value is 1.
-    pub value: Option<Dist>,
+    /// distribution.
+    pub dist: Option<Dist>,
+    /// If set, the counter will be updated by the other counter's value *prior
+    /// to transitioning to the state*. Supersedes the `dist` field.
+    pub copy: bool,
 }
 
-impl fmt::Display for CounterUpdate {
+impl fmt::Display for Counter {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:#?}", self)
     }
 }
 
-impl CounterUpdate {
+impl Counter {
+    /// Create a new counter with an operation that modifies the counter with
+    /// value 1.
+    pub fn new(operation: Operation) -> Self {
+        Counter {
+            operation,
+            dist: None,
+            copy: false,
+        }
+    }
+
+    /// Create a new counter with an operation and a distribution to sample the
+    /// value from.
+    pub fn new_dist(operation: Operation, dist: Dist) -> Self {
+        Counter {
+            operation,
+            dist: Some(dist),
+            copy: false,
+        }
+    }
+
+    /// Create a new counter with an operation that copies the value of the
+    /// other counter *prior to transitioning to the state*.
+    pub fn new_copy(operation: Operation) -> Self {
+        Counter {
+            operation,
+            dist: None,
+            copy: true,
+        }
+    }
+
     /// Sample a value to update the counter with.
     pub fn sample_value<R: RngCore>(&self, rng: &mut R) -> u64 {
-        match self.value {
-            Some(value) => {
-                let s = value.sample(rng) as u64;
+        match self.dist {
+            None => 1,
+            Some(dist) => {
+                let s = dist.sample(rng) as u64;
                 s.min(MAX_SAMPLED_COUNTER_VALUE)
             }
-            None => 1,
         }
     }
 
     // Validate the value dist.
     pub fn validate(&self) -> Result<(), Error> {
-        if let Some(value) = self.value {
-            value.validate()?;
+        if let Some(dist) = self.dist {
+            dist.validate()?;
         }
         Ok(())
     }
@@ -77,24 +107,23 @@ mod tests {
     #[test]
     fn validate_counter_update() {
         // valid counter update
-        let mut cu = CounterUpdate {
-            counter: Counter::A,
-            operation: Operation::Increment,
-            value: Some(Dist {
+        let mut cu = Counter::new_dist(
+            Operation::Increment,
+            Dist {
                 dist: DistType::Uniform {
                     low: 10.0,
                     high: 10.0,
                 },
                 start: 0.0,
                 max: 0.0,
-            }),
-        };
+            },
+        );
 
         let r = cu.validate();
         assert!(r.is_ok());
 
         // counter update with invalid dist
-        cu.value = Some(Dist {
+        cu.dist = Some(Dist {
             dist: DistType::Uniform {
                 low: 15.0, // NOTE low > high
                 high: 5.0,
@@ -106,12 +135,18 @@ mod tests {
         let r = cu.validate();
         assert!(r.is_err());
 
-        // counter with empty dist
-        cu.value = None;
+        // counter with default value
+        cu.dist = None;
 
         let r = cu.validate();
         assert!(r.is_ok());
 
         assert_eq!(cu.sample_value(&mut rand::thread_rng()), 1);
+
+        // counter with copy value
+        cu.copy = true;
+
+        let r = cu.validate();
+        assert!(r.is_ok());
     }
 }

--- a/crates/maybenot/src/event.rs
+++ b/crates/maybenot/src/event.rs
@@ -38,6 +38,8 @@ pub enum Event {
     TimerBegin,
     /// TimerEnd is when a machine's timer expired.
     TimerEnd,
+    /// Signal is when a machine transitioned to [`STATE_SIGNAL`](crate::constants).
+    Signal,
 }
 
 impl fmt::Display for Event {
@@ -61,6 +63,7 @@ impl Event {
             CounterZero,
             TimerBegin,
             TimerEnd,
+            Signal,
         ];
         EVENTS.iter()
     }
@@ -153,5 +156,6 @@ mod tests {
         assert_eq!(Event::TimerEnd.to_string(), "TimerEnd");
         assert_eq!(Event::TunnelRecv.to_string(), "TunnelRecv");
         assert_eq!(Event::TunnelSent.to_string(), "TunnelSent");
+        assert_eq!(Event::Signal.to_string(), "Signal");
     }
 }

--- a/crates/maybenot/src/lib.rs
+++ b/crates/maybenot/src/lib.rs
@@ -34,7 +34,7 @@
 //! // of the framework for the same machines, then share the same vector
 //! // across framework instances. All runtime information is allocated
 //! // internally in the framework without modifying the machines.
-//! let s = "02eNpjYEAHjKhcAAAwAAI=";
+//! let s = "02eNpjYEAHjOgCAAA0AAI=";
 //! // machines will error if invalid
 //! let m = vec![Machine::from_str(s).unwrap()];
 //!
@@ -247,7 +247,7 @@ mod tests {
         // of the framework for the same machines, then share the same vector
         // across framework instances. All runtime information is allocated
         // internally in the framework without modifying the machines.
-        let s = "02eNpjYEAHjKhcAAAwAAI=";
+        let s = "02eNpjYEAHjOgCAAA0AAI=";
         // machines will error if invalid
         let m = vec![Machine::from_str(s).unwrap()];
 


### PR DESCRIPTION
- Added support for internal signalling between machines with Event::Signal.
- It is now possible to update both counters on state transition.
- A counter operation can now use the value of the other counter.
- Updated changelog, also with minor clarifications.

@faern and @ewitwer , please have a look. I squashed the history.