### PR TITLE
Limit `trigger_events` lifetime bounds

### DIFF
--- a/crates/maybenot/src/framework.rs
+++ b/crates/maybenot/src/framework.rs
@@ -218,11 +218,11 @@ where
     ///
     /// Returns an iterator of zero or more [`TriggerAction`] that MUST be taken
     /// by the caller.
-    pub fn trigger_events(
-        &mut self,
+    pub fn trigger_events<'a>(
+        &'a mut self,
         events: &[TriggerEvent],
         current_time: T,
-    ) -> impl Iterator<Item = &TriggerAction<T>> {
+    ) -> impl Iterator<Item = &'a TriggerAction<T>> + use<'a, M, R, T> {
         // reset all actions
         self.actions.fill(None);
 


### PR DESCRIPTION
Prevent the lifetime of the returned actions from being bound to `events: &[TriggerEvent]`, when they actually only depend on the lifetime of `&mut self`. This allows one to mutate the events buffer before handling each action.

Makes it possible to clear the events buffer and add `TimerBegin` events to it from `UpdateTimer` actions, in preparation for the next `trigger_events` call.