### PR TITLE
ffi: bump framework to 2.2.2

### DIFF
--- a/crates/maybenot-ffi/Cargo.toml
+++ b/crates/maybenot-ffi/Cargo.toml
@@ -13,6 +13,6 @@ repository.workspace = true
 crate-type = ["lib", "staticlib", "cdylib"]
 
 [dependencies]
-maybenot = { version = "2.1.0", path = "../maybenot" }
+maybenot = { version = "2.2.2", path = "../maybenot" }
 rand = "0.9"
 rand_chacha = "0.9"


### PR DESCRIPTION
This PR update the `maybenot` version used by the `maybenot-ffi` crate.