### PR TITLE
Remove unused dependencies (and automatically check for it in CI)

### DIFF
--- a/.github/workflows/cargo-shear.yml
+++ b/.github/workflows/cargo-shear.yml
@@ -1,0 +1,23 @@
+---
+name: Unused dependencies
+on:
+  pull_request:
+    paths:
+      - .github/workflows/cargo-shear.yml
+      - "**/*.rs"
+      - "**/Cargo.toml"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  cargo-shear:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install cargo-shear
+        uses: taiki-e/install-action@cargo-shear
+
+      - name: Run cargo shear
+        run: cargo shear

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -13,15 +13,15 @@ repository.workspace = true
 workspace = true
 
 [dependencies]
-maybenot = { path = "../crates/maybenot/" }
-maybenot-simulator = { path = "../crates/maybenot-simulator" }
-rand = "0.9"
-rand_xoshiro = "0.7"
-rand_core = "0.9"
 
 [dev-dependencies]
 criterion = "0.5.1"
 enum-map = "2.7.3"
+maybenot = { path = "../crates/maybenot/" }
+maybenot-simulator = { path = "../crates/maybenot-simulator" }
+rand = "0.9"
+rand_core = "0.9"
+rand_xoshiro = "0.7"
 
 [[bench]]
 name = "rng"

--- a/crates/maybenot-cli/Cargo.toml
+++ b/crates/maybenot-cli/Cargo.toml
@@ -29,7 +29,6 @@ maybenot-gen = { version = "1.0.1", path = "../maybenot-gen" }
 maybenot-machines = { version = "1.0.1", path = "../maybenot-machines" }
 num_cpus = "1.17"
 rand = "0.9"
-rand_core = "0.9"
 rand_seeder = "0.4"
 rand_xoshiro = "0.7"
 rayon = "1.10"

--- a/crates/maybenot-gen/Cargo.toml
+++ b/crates/maybenot-gen/Cargo.toml
@@ -24,7 +24,6 @@ num-integer = "0.1"
 num-traits = "0.2"
 petgraph = "0.8"
 rand = "0.9"
-rand_core = "0.9"
 rand_seeder = "0.4"
 rand_xoshiro = "0.7"
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/maybenot-simulator/Cargo.toml
+++ b/crates/maybenot-simulator/Cargo.toml
@@ -24,5 +24,3 @@ rand_xoshiro = "0.7"
 [dev-dependencies]
 enum-map = "2.7"
 test-log = "0.2.18"
-rand_core = "0.9"
-env_logger = "0.11"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -20,7 +20,6 @@ fuzzing = []
 afl = "0.15.13"
 rand = "0.9"
 rand_xoshiro = "0.7"
-rand_core = "0.9"
 maybenot = { path = "../crates/maybenot/" }
 
 [[bin]]


### PR DESCRIPTION
We very recently started using [`cargo shear`](https://crates.io/crates/cargo-shear) at Mullvad. It works really well for detecting unused or misplaced dependencies. It was able to detect a few possible cleanups in this repository!

I added the same CI job we have in Rust crates for automatically running `cargo shear` and throw errors if we have unused or misplaced dependencies.
